### PR TITLE
Added x:Keys to all controls styles, so it's possible to base styles on them.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,3 +12,4 @@
 
 Geert van Horrik <geert@catenalogic.com>
 Maksim Khomutov <mkhomutov@gmail.com>
+Michal Vacha <michal.vacha@live.com>

--- a/src/Orc.Controls/Orc.Controls.Shared/Controls/ColorLegend/Themes/ColorLegend.generic.xaml
+++ b/src/Orc.Controls/Orc.Controls.Shared/Controls/ColorLegend/Themes/ColorLegend.generic.xaml
@@ -207,7 +207,8 @@
         </Setter>
     </Style>
 
-    <Style TargetType="{x:Type controls:ColorLegend}">
+    <Style x:Key="{x:Type controls:ColorLegend}"
+           TargetType="{x:Type controls:ColorLegend}">
         <Style.Resources>
             <Style TargetType="{x:Type CheckBox}" BasedOn="{StaticResource ColorLegendCheckBoxStyle}"/>
             <Style TargetType="{x:Type TabItem}" BasedOn="{x:Null}"/>

--- a/src/Orc.Controls/Orc.Controls.Shared/Controls/ColorPicker/Themes/ColorPicker.generic.xaml
+++ b/src/Orc.Controls/Orc.Controls.Shared/Controls/ColorPicker/Themes/ColorPicker.generic.xaml
@@ -2,7 +2,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:Orc.Controls">
 
-    <Style TargetType="{x:Type local:ColorPicker}">
+    <Style x:Key="{x:Type local:ColorPicker}"
+           TargetType="{x:Type local:ColorPicker}">
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>

--- a/src/Orc.Controls/Orc.Controls.Shared/Controls/ColorPicker/Themes/ColorPicker.xaml
+++ b/src/Orc.Controls/Orc.Controls.Shared/Controls/ColorPicker/Themes/ColorPicker.xaml
@@ -2,7 +2,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="clr-namespace:Orc.Controls">
 
-    <Style TargetType="{x:Type controls:ColorPicker}">
+    <Style x:Key="{x:Type controls:ColorPicker}"
+           TargetType="{x:Type controls:ColorPicker}">
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>

--- a/src/Orc.Controls/Orc.Controls.Shared/Controls/DatePicker/Themes/DatePickerControl.generic.xaml
+++ b/src/Orc.Controls/Orc.Controls.Shared/Controls/DatePicker/Themes/DatePickerControl.generic.xaml
@@ -21,7 +21,8 @@
     </ControlTemplate>
 
     <!-- Dummy base style -->
-    <Style TargetType="{x:Type local:DatePickerControl}"/>
+    <Style x:Key="{x:Type local:DatePickerControl}"
+           TargetType="{x:Type local:DatePickerControl}"/>
     
     <Style x:Key="DatePickerToggleButtonStyle" TargetType="{x:Type ToggleButton}">
         <Setter Property="Width" Value="19"/>

--- a/src/Orc.Controls/Orc.Controls.Shared/Controls/DateTimePicker/Themes/DateTimePickerControl.generic.xaml
+++ b/src/Orc.Controls/Orc.Controls.Shared/Controls/DateTimePicker/Themes/DateTimePickerControl.generic.xaml
@@ -21,7 +21,8 @@
     </ControlTemplate>
 
     <!-- Dummy base style -->
-    <Style TargetType="{x:Type local:DateTimePickerControl}"/>
+    <Style x:Key="{x:Type local:DateTimePickerControl}"
+           TargetType="{x:Type local:DateTimePickerControl}"/>
 
     <Style x:Key="DateTimePickerInnerGridStyle" TargetType="{x:Type Grid}">
         <Style.Triggers>

--- a/src/Orc.Controls/Orc.Controls.Shared/Controls/DropDownButton/Themes/DropDownButton.generic.xaml
+++ b/src/Orc.Controls/Orc.Controls.Shared/Controls/DropDownButton/Themes/DropDownButton.generic.xaml
@@ -2,7 +2,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:Orc.Controls">
 
-    <Style TargetType="{x:Type local:DropDownButton}">
+    <Style x:Key="{x:Type local:DropDownButton}"
+           TargetType="{x:Type local:DropDownButton}">
         <Style.Resources>
             <Style TargetType="{x:Type Button}">
                 <Setter Property="Padding" Value="4 2 4 2"/>

--- a/src/Orc.Controls/Orc.Controls.Shared/Controls/Expander/Themes/Expander.generic.xaml
+++ b/src/Orc.Controls/Orc.Controls.Shared/Controls/Expander/Themes/Expander.generic.xaml
@@ -6,9 +6,9 @@
     <Geometry x:Key="UnpinnedGeometry">M550.98,271.481L550.98,496.519C534.954,498.998 515.4,480.395 510.981,456.338L430.694,461.359C421.048,499.288 389.117,513.621 370.226,511.94L370.644,401.232L274.045,400.802L217.02,384L274.047,367.198L370.644,366.768L370.226,256.06C389.117,254.379 421.048,268.712 430.694,306.641L510.981,311.662C515.4,287.605 534.954,269.002 550.98,271.481Z</Geometry>
 
     <!-- Dummy base style -->
-    <Style TargetType="{x:Type local:Expander}">
-    </Style>    
-    
+    <Style x:Key="{x:Type local:Expander}"
+           TargetType="{x:Type local:Expander}"/>
+
     <Style x:Key="Pin_ToggleButton" TargetType="{x:Type ToggleButton}">
         <Setter Property="OverridesDefaultStyle" Value="True"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>

--- a/src/Orc.Controls/Orc.Controls.Shared/Controls/FilterBox/Themes/FilterBox.generic.xaml
+++ b/src/Orc.Controls/Orc.Controls.Shared/Controls/FilterBox/Themes/FilterBox.generic.xaml
@@ -4,7 +4,8 @@
                     xmlns:catel="http://catel.codeplex.com"
                     xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity">
 
-    <Style TargetType="{x:Type local:FilterBoxControl}">
+    <Style x:Key="{x:Type local:FilterBoxControl}"
+           TargetType="{x:Type local:FilterBoxControl}">
         <Style.Resources>
            <Style TargetType="{x:Type ListBoxItem}">
                 <Setter Property="Template">

--- a/src/Orc.Controls/Orc.Controls.Shared/Controls/HeaderBar/Themes/HeaderBar.generic.xaml
+++ b/src/Orc.Controls/Orc.Controls.Shared/Controls/HeaderBar/Themes/HeaderBar.generic.xaml
@@ -2,7 +2,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="clr-namespace:Orc.Controls">
 
-    <Style TargetType="{x:Type controls:HeaderBar}">
+    <Style x:Key="{x:Type controls:HeaderBar}"
+           TargetType="{x:Type controls:HeaderBar}">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate>

--- a/src/Orc.Controls/Orc.Controls.Shared/Controls/LinkLabel/Themes/LinkLabel.generic.xaml
+++ b/src/Orc.Controls/Orc.Controls.Shared/Controls/LinkLabel/Themes/LinkLabel.generic.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                    xmlns:controls="clr-namespace:Orc.Controls">
 
-    <Style TargetType="{x:Type controls:LinkLabel}" BasedOn="{StaticResource {x:Type Label}}">
+    <Style x:Key="{x:Type controls:LinkLabel}" TargetType="{x:Type controls:LinkLabel}" BasedOn="{StaticResource {x:Type Label}}">
         <Setter Property="Foreground" Value="Blue"/>
         <Setter Property="HoverForeground" Value="Red"/>
 

--- a/src/Orc.Controls/Orc.Controls.Shared/Controls/LogViewer/Themes/LogViewer.generic.xaml
+++ b/src/Orc.Controls/Orc.Controls.Shared/Controls/LogViewer/Themes/LogViewer.generic.xaml
@@ -2,7 +2,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:Orc.Controls">
 
-    <Style TargetType="{x:Type local:LogViewerControl}">
+    <Style x:Key="{x:Type local:LogViewerControl}"
+           TargetType="{x:Type local:LogViewerControl}">
         <Style.Resources>
             <Style TargetType="{x:Type local:RichTextBoxParagraph}">
                 <Setter Property="Margin" Value="0"/>

--- a/src/Orc.Controls/Orc.Controls.Shared/Controls/PinnableToolTips/Themes/PinnableToolTip.xaml
+++ b/src/Orc.Controls/Orc.Controls.Shared/Controls/PinnableToolTips/Themes/PinnableToolTip.xaml
@@ -103,7 +103,8 @@
         </Setter>
     </Style>
 
-    <Style TargetType="controls:PinnableToolTip">
+    <Style x:Key="{x:Type controls:PinnableToolTip}"
+           TargetType="{x:Type controls:PinnableToolTip}">
         <Setter Property="Padding" Value="0"/>
         <Setter Property="Background" Value="White" />
         <Setter Property="BorderThickness" Value="1" />

--- a/src/Orc.Controls/Orc.Controls.Shared/Controls/TimeSpan/Themes/TimeSpan.generic.xaml
+++ b/src/Orc.Controls/Orc.Controls.Shared/Controls/TimeSpan/Themes/TimeSpan.generic.xaml
@@ -34,7 +34,8 @@
         </Style.Triggers>
     </Style>
 
-    <Style TargetType="{x:Type local:TimeSpanControl}">
+    <Style x:Key="{x:Type local:TimeSpanControl}"
+           TargetType="{x:Type local:TimeSpanControl}">
         <Style.Resources>
             <Style TargetType="{x:Type Border}">
                 <Setter Property="BorderBrush" Value="LightGray"/>

--- a/src/Orc.Controls/Orc.Controls.Shared/Controls/ValidationContextControl/Themes/ValidationContextControl.generic.xaml
+++ b/src/Orc.Controls/Orc.Controls.Shared/Controls/ValidationContextControl/Themes/ValidationContextControl.generic.xaml
@@ -8,8 +8,9 @@
     <Geometry x:Key="ArrowsInGeometry">M19.5,3.09L20.91,4.5L16.41,9H20V11H13V4H15V7.59L19.5,3.09M20.91,19.5L19.5,20.91L15,16.41V20H13V13H20V15H16.41L20.91,19.5M4.5,3.09L9,7.59V4H11V11H4V9H7.59L3.09,4.5L4.5,3.09M3.09,19.5L7.59,15H4V13H11V20H9V16.41L4.5,20.91L3.09,19.5Z</Geometry>
 
     <!-- Dummy base style -->
-    <Style TargetType="{x:Type local:ValidationContextView}">
-    </Style>
+    <Style x:Key="{x:Type local:ValidationContextView}"
+           TargetType="{x:Type local:ValidationContextView}"/>
+
 
     <Style x:Key="ValidationContextToggleButtonStyle" TargetType="{x:Type ToggleButton}">
         <Setter Property="Template">

--- a/src/Orc.Controls/Orc.Controls.Shared/Controls/WatermarkTextBox/Themes/WatermarkTextBox.generic.xaml
+++ b/src/Orc.Controls/Orc.Controls.Shared/Controls/WatermarkTextBox/Themes/WatermarkTextBox.generic.xaml
@@ -29,7 +29,8 @@
                         Foreground="Gray" />
     </DataTemplate>
 
-    <Style TargetType="{x:Type controls:WatermarkTextBox}">
+    <Style x:Key="{x:Type controls:WatermarkTextBox}"
+           TargetType="{x:Type controls:WatermarkTextBox}">
         <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
         <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" />
         <Setter Property="BorderBrush" Value="{StaticResource TextBoxBorder}" />


### PR DESCRIPTION
Added x:Keys to all controls styles, so now it follows the convention from WPF framework:
`<Style x:Key="{x:Type CONTROL}" TargetType="{x:Type CONTROL}">`

Fixes # 17.

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)
