### PR TITLE
Feature/orcomp 616

### DIFF
--- a/src/Orc.Controls/Controls/DateTimePicker/DateTimePicker.cs
+++ b/src/Orc.Controls/Controls/DateTimePicker/DateTimePicker.cs
@@ -616,15 +616,22 @@ namespace Orc.Controls
             UpdateUi();
         }
 
-        protected override void OnIsKeyboardFocusedChanged(DependencyPropertyChangedEventArgs e)
-        {
-            base.OnIsKeyboardFocusedChanged(e);
+        //protected override void OnIsKeyboardFocusedChanged(DependencyPropertyChangedEventArgs e)
+        //{
+        //    base.OnIsKeyboardFocusedChanged(e);
 
-            var textBox = _textBoxes[0];
+        //    if (IsFocused && IsKeyboardFocused)
+        //    {
+        //        var textBox = _textBoxes.FirstOrDefault();
+        //        if (textBox is null)
+        //        {
+        //            return;
+        //        }
 
-            textBox.SetCurrentValue(FocusableProperty, true);
-            Keyboard.Focus(textBox);
-        }
+        //        textBox.SetCurrentValue(FocusableProperty, true);
+        //        Keyboard.Focus(textBox);
+        //    }
+        //}
 
         private void OnTodayMenuItemClick(object sender, RoutedEventArgs e)
         {
@@ -1619,17 +1626,6 @@ namespace Orc.Controls
         {
             base.OnPreviewKeyDown(e);
 
-            if (e.Key == Key.Tab && KeyboardHelper.AreKeyboardModifiersPressed(ModifierKeys.Shift))
-            {
-                var request = new TraversalRequest(FocusNavigationDirection.Previous);
-                var elementWithFocus = Keyboard.FocusedElement as UIElement;
-                if (elementWithFocus?.MoveFocus(request) ?? false)
-                {
-                    e.Handled = true;
-                    return;
-                }
-            }
-
             if (e.Key != Key.OemSemicolon)
             {
                 return;
@@ -1697,6 +1693,23 @@ namespace Orc.Controls
             ((Popup)calendar.Parent).SetCurrentValue(Popup.IsOpenProperty, false);
 
             e.Handled = true;
+        }
+
+        protected override void OnIsKeyboardFocusWithinChanged(DependencyPropertyChangedEventArgs e)
+        {
+            if ((bool)e.NewValue)
+            {
+                var textBox = _textBoxes.FirstOrDefault();
+                if (textBox is null)
+                {
+                    return;
+                }
+
+                textBox.SetCurrentValue(FocusableProperty, true);
+                Keyboard.Focus(textBox);
+            }
+
+            base.OnIsKeyboardFocusWithinChanged(e);
         }
 
         protected override void OnGotKeyboardFocus(KeyboardFocusChangedEventArgs e)

--- a/src/Orc.Controls/Controls/DateTimePicker/DateTimePicker.cs
+++ b/src/Orc.Controls/Controls/DateTimePicker/DateTimePicker.cs
@@ -1625,6 +1625,7 @@ namespace Orc.Controls
                 var elementWithFocus = Keyboard.FocusedElement as UIElement;
                 elementWithFocus?.MoveFocus(request);
                 e.Handled = true;
+                return;
             }
 
             if (e.Key != Key.OemSemicolon)

--- a/src/Orc.Controls/Controls/DateTimePicker/DateTimePicker.cs
+++ b/src/Orc.Controls/Controls/DateTimePicker/DateTimePicker.cs
@@ -1619,6 +1619,14 @@ namespace Orc.Controls
         {
             base.OnPreviewKeyDown(e);
 
+            if (e.Key == Key.Tab && KeyboardHelper.AreKeyboardModifiersPressed(ModifierKeys.Shift))
+            {
+                var request = new TraversalRequest(FocusNavigationDirection.Previous);
+                var elementWithFocus = Keyboard.FocusedElement as UIElement;
+                elementWithFocus?.MoveFocus(request);
+                e.Handled = true;
+            }
+
             if (e.Key != Key.OemSemicolon)
             {
                 return;

--- a/src/Orc.Controls/Controls/DateTimePicker/DateTimePicker.cs
+++ b/src/Orc.Controls/Controls/DateTimePicker/DateTimePicker.cs
@@ -616,23 +616,6 @@ namespace Orc.Controls
             UpdateUi();
         }
 
-        //protected override void OnIsKeyboardFocusedChanged(DependencyPropertyChangedEventArgs e)
-        //{
-        //    base.OnIsKeyboardFocusedChanged(e);
-
-        //    if (IsFocused && IsKeyboardFocused)
-        //    {
-        //        var textBox = _textBoxes.FirstOrDefault();
-        //        if (textBox is null)
-        //        {
-        //            return;
-        //        }
-
-        //        textBox.SetCurrentValue(FocusableProperty, true);
-        //        Keyboard.Focus(textBox);
-        //    }
-        //}
-
         private void OnTodayMenuItemClick(object sender, RoutedEventArgs e)
         {
             UpdateDateTime(DateTime.Today.Date);

--- a/src/Orc.Controls/Controls/DateTimePicker/Themes/DateTimePicker.generic.xaml
+++ b/src/Orc.Controls/Controls/DateTimePicker/Themes/DateTimePicker.generic.xaml
@@ -114,6 +114,7 @@
         </Style.Resources>
 
         <Setter Property="controls:EnterKeyTraversal.IsEnabled" Value="True"/>
+        <Setter Property="Focusable" Value="False" />
 
         <Setter Property="Template">
             <Setter.Value>


### PR DESCRIPTION
### Description of Change ###

Now works as expected. You can make shift + tab to the previous control from DateTimePicker

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- All
- WPF
- UWP
- iOS
- Android

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
