### PR TITLE
Hotfix/4.4.1

### DIFF
--- a/src/Orc.Controls.Example/Models/CultureFormat.cs
+++ b/src/Orc.Controls.Example/Models/CultureFormat.cs
@@ -5,9 +5,12 @@
 // --------------------------------------------------------------------------------------------------------------------
 namespace Orc.Controls.Example.Models
 {
+    using System.Globalization;
+
     public class CultureFormat
     {
-        public string CultureCode { get; set; }
+        public CultureInfo Culture { get; set; }
+        public string CultureCode => $"[{Culture?.IetfLanguageTag}]";
         public string FormatValue { get; set; }
     }
 }

--- a/src/Orc.Controls.Example/ViewModels/DateTimePickerViewModel.cs
+++ b/src/Orc.Controls.Example/ViewModels/DateTimePickerViewModel.cs
@@ -47,7 +47,7 @@ namespace Orc.Controls.Example.ViewModels
                 {
                     var format = new CultureFormat
                     {
-                        CultureCode = $"[{cultureInfo.IetfLanguageTag}]",
+                        Culture = cultureInfo,
                         FormatValue = cultureInfo.DateTimeFormat.ShortDatePattern + " " + cultureInfo.DateTimeFormat.LongTimePattern
                     };
 
@@ -55,7 +55,7 @@ namespace Orc.Controls.Example.ViewModels
 
                     format = new CultureFormat
                     {
-                        CultureCode = $"[{cultureInfo.IetfLanguageTag}]",
+                        Culture = cultureInfo,
                         FormatValue = cultureInfo.DateTimeFormat.ShortDatePattern
                     };
 
@@ -63,7 +63,7 @@ namespace Orc.Controls.Example.ViewModels
 
                     format = new CultureFormat
                     {
-                        CultureCode = $"[{cultureInfo.IetfLanguageTag}]",
+                        Culture = cultureInfo,
                         FormatValue = cultureInfo.DateTimeFormat.ShortDatePattern + " " + cultureInfo.DateTimeFormat.ShortTimePattern
                     };
 

--- a/src/Orc.Controls.Example/Views/DateTimePicker.xaml
+++ b/src/Orc.Controls.Example/Views/DateTimePicker.xaml
@@ -27,15 +27,16 @@
         <StackPanel Orientation="Horizontal">
             <TextBlock Text="DateTimePicker Control" VerticalAlignment="Center" Width="150"/>
             <orccontrols:DateTimePicker Value="{Binding DateTimeValue}"
-                                       Format="{Binding SelectedFormat.FormatValue}" HorizontalAlignment="Left"
-                                       AllowNull="{Binding IsChecked, ElementName=allowNullCheckbox}"
-                                       AllowCopyPaste="{Binding IsChecked, ElementName=allowCopyPasteCheckbox}"
-                                       HideTime="{Binding IsChecked, ElementName=hideTimeCheckbox}"
-                                       HideSeconds="{Binding IsChecked, ElementName=hideSecondsCheckbox}"
-                                       IsReadOnly="{Binding IsChecked, ElementName=readOnlyCheckbox}"
-                                       ShowOptionsButton="{Binding IsChecked, ElementName=showOptionsButtonCheckbox}" 
-                                       EditStarted="DateTimePicker_OnEditStarted"
-                                       EditEnded="DateTimePicker_OnEditEnded"/>
+                                        Culture="{Binding SelectedFormat.Culture}"
+                                        Format="{Binding SelectedFormat.FormatValue}" HorizontalAlignment="Left"
+                                        AllowNull="{Binding IsChecked, ElementName=allowNullCheckbox}"
+                                        AllowCopyPaste="{Binding IsChecked, ElementName=allowCopyPasteCheckbox}"
+                                        HideTime="{Binding IsChecked, ElementName=hideTimeCheckbox}"
+                                        HideSeconds="{Binding IsChecked, ElementName=hideSecondsCheckbox}"
+                                        IsReadOnly="{Binding IsChecked, ElementName=readOnlyCheckbox}"
+                                        ShowOptionsButton="{Binding IsChecked, ElementName=showOptionsButtonCheckbox}" 
+                                        EditStarted="DateTimePicker_OnEditStarted"
+                                        EditEnded="DateTimePicker_OnEditEnded"/>
         </StackPanel>
         
         <StackPanel Orientation="Horizontal">

--- a/src/Orc.Controls/Controls/DateTimePicker/DateTimePicker.cs
+++ b/src/Orc.Controls/Controls/DateTimePicker/DateTimePicker.cs
@@ -789,7 +789,7 @@ namespace Orc.Controls
 
                 SetCurrentValue(HideTimeProperty, !hasAnyTimeFormat || _safeHideTimeValue);
 
-                var culture = GetCulture();
+                var culture = Culture ?? CultureInfo.CurrentUICulture;
                 var firstDayOfWeek = FirstDayOfWeek ?? culture.DateTimeFormat.FirstDayOfWeek;
 
                 _calendar.SetCurrentValue(Calendar.FirstDayOfWeekProperty, firstDayOfWeek);
@@ -797,7 +797,9 @@ namespace Orc.Controls
                 if (!hasLongTimeFormat)
                 {
                     var timePattern = DateTimeFormatHelper.ExtractTimePatternFromFormat(format);
-                    if (!string.IsNullOrEmpty(timePattern))
+
+                    //Find matching format from culture, if no culture just use specified format
+                    if (Culture is not null && !string.IsNullOrEmpty(timePattern))
                     {
                         timePattern = DateTimeFormatHelper.FindMatchedLongTimePattern(culture, timePattern);
                     }
@@ -1773,11 +1775,6 @@ namespace Orc.Controls
             IsInEditMode = false;
 
             EditEnded?.Invoke(this, EventArgs.Empty);
-        }
-
-        private CultureInfo GetCulture()
-        {
-            return Culture ?? CultureInfo.CurrentUICulture;
         }
 
         private void TryProceedSecondMinuteEditing(TextBox secondOrMinuteTextBox)

--- a/src/Orc.Controls/Controls/NumericTextBox/NumericTextBox.cs
+++ b/src/Orc.Controls/Controls/NumericTextBox/NumericTextBox.cs
@@ -393,9 +393,10 @@ namespace Orc.Controls
                     var culture = CultureInfo ?? CultureInfo.CurrentCulture;
 
                     var factor = 1d;
-                    if (text.Contains(culture.NumberFormat.PercentSymbol))
+                    var percentSymbol = culture.NumberFormat.PercentSymbol;
+                    if (text.Contains(percentSymbol))
                     {
-                        text = text.Replace(culture.NumberFormat.PercentSymbol, string.Empty);
+                        text = text.Replace(percentSymbol, string.Empty);
                         factor = 1d / 100;
                     }
 

--- a/src/Orc.Controls/Controls/NumericTextBox/NumericTextBox.cs
+++ b/src/Orc.Controls/Controls/NumericTextBox/NumericTextBox.cs
@@ -389,8 +389,18 @@ namespace Orc.Controls
             {
                 if (!string.IsNullOrEmpty(text))
                 {
+
+                    var culture = CultureInfo ?? CultureInfo.CurrentCulture;
+
+                    var factor = 1d;
+                    if (text.Contains(culture.NumberFormat.PercentSymbol))
+                    {
+                        text = text.Replace(culture.NumberFormat.PercentSymbol, string.Empty);
+                        factor = 1d / 100;
+                    }
+
                     // TODO: Do we want to handle P2, etc (e.g. 50.00%)
-                    doubleValue = Convert.ToDouble(text, CultureInfo ?? CultureInfo.CurrentCulture);
+                    doubleValue = Convert.ToDouble(text, CultureInfo ?? CultureInfo.CurrentCulture) * factor;
                 }
             }
             catch (Exception)

--- a/src/Orc.Controls/Helpers/DateTimeFormatHelper.cs
+++ b/src/Orc.Controls/Helpers/DateTimeFormatHelper.cs
@@ -113,7 +113,9 @@ namespace Orc.Controls
                 .Select(ExtractTimePatternFromFormat).Distinct()
                 .Where(x => !string.IsNullOrWhiteSpace(x))
                 .Select(x => new {Pattern = x, MatchesCount = x.Count(y => timeChars.Contains(y))})
-                .OrderByDescending(x => x.MatchesCount).Select(x => x.Pattern);
+                .OrderByDescending(x => x.MatchesCount)
+                .Select(x => x.Pattern)
+                .ToList();
 
             var result = patterns.FirstOrDefault() ?? string.Empty;
 


### PR DESCRIPTION
fixes:
ORCOMP-636 Support Percentage format (P0..N) in NumericTextBox
ORCOMP-635 Wrong formatting HH:mm


