### PR TITLE
GFG-392 reset focus to let the date change

### DIFF
--- a/src/Orc.Controls/Controls/DateTimePicker/DateTimePicker.cs
+++ b/src/Orc.Controls/Controls/DateTimePicker/DateTimePicker.cs
@@ -1068,6 +1068,10 @@ namespace Orc.Controls
                 dispatcherService.Invoke(() => SetCurrentValue(ValueProperty, nv));
             }
 
+            SetCurrentValue(FocusableProperty, true);
+            Focus();
+            SetCurrentValue(FocusableProperty, false);
+
             UpdateUi();
         }
 


### PR DESCRIPTION
### Description of Change ###

The problem was that after selecting "Today" the focus moves to the first NumericTextBox and blocks it from updating its value

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- All
- WPF
- UWP
- iOS
- Android

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
