### PR TITLE
Feature/font image

### DIFF
--- a/src/Orc.Controls.Example/ViewModels/FontImageViewModel.cs
+++ b/src/Orc.Controls.Example/ViewModels/FontImageViewModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Orc.Controls.Example.ViewModels
+{
+    using Catel.MVVM;
+
+    public class FontImageViewModel : ViewModelBase
+    {
+    }
+}

--- a/src/Orc.Controls.Example/Views/FontImageView.xaml
+++ b/src/Orc.Controls.Example/Views/FontImageView.xaml
@@ -1,0 +1,43 @@
+﻿<catel:UserControl x:Class="Orc.Controls.Example.Views.FontImageView"
+                   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                   xmlns:catel="http://schemas.catelproject.com"
+                   xmlns:orccontrols="http://schemas.wildgums.com/orc/controls">
+
+    <orccontrols:StackGrid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <Label Content="Item:"/>
+        <TextBox x:Name="ItemNameTextBox"
+                 Text="A"/>
+
+        <Label Content="Font:"/>
+        <TextBox x:Name="FontTextBox"
+                 Text="Segoe UI"/>
+
+        <Label Content="Background:"/>
+        <orccontrols:ColorPicker x:Name="BackgroundColorPicker"
+                                 Color="LightPink"/>
+
+        <Label Content="Foreground:"/>
+        <orccontrols:ColorPicker x:Name="ForegroundColorPicker"
+                                 Color="Black"/>
+
+        <orccontrols:FontImage Grid.ColumnSpan="2"
+                               FontFamily="{Binding ElementName=FontTextBox, Path=Text}"
+                               ItemName="{Binding ElementName=ItemNameTextBox, Path=Text}"
+                               Background="{Binding ElementName=BackgroundColorPicker, Path=Color, Converter={catel:ColorToBrushConverter}}"
+                               Foreground="{Binding ElementName=ForegroundColorPicker, Path=Color, Converter={catel:ColorToBrushConverter}}"/>
+    </orccontrols:StackGrid>
+    
+</catel:UserControl>

--- a/src/Orc.Controls.Example/Views/FontImageView.xaml.cs
+++ b/src/Orc.Controls.Example/Views/FontImageView.xaml.cs
@@ -1,6 +1,5 @@
 ﻿namespace Orc.Controls.Example.Views
 {
-
     public partial class FontImageView
     {
         public FontImageView()

--- a/src/Orc.Controls.Example/Views/FontImageView.xaml.cs
+++ b/src/Orc.Controls.Example/Views/FontImageView.xaml.cs
@@ -1,0 +1,11 @@
+﻿namespace Orc.Controls.Example.Views
+{
+
+    public partial class FontImageView
+    {
+        public FontImageView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Orc.Controls.Example/Views/MainWindow.xaml
+++ b/src/Orc.Controls.Example/Views/MainWindow.xaml
@@ -84,6 +84,10 @@
                 <views:FilterBox />
             </TabItem>
 
+            <TabItem Header="FontImage">
+                <views:FontImageView />
+            </TabItem>
+
             <TabItem Header="FluidProgressBar">
                 <views:FluidProgressBar />
             </TabItem>

--- a/src/Orc.Controls.sln.DotSettings
+++ b/src/Orc.Controls.sln.DotSettings
@@ -439,6 +439,7 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
   Copyright (c) 2008 - $CURRENT_YEAR$ WildGums. All rights reserved.&#xD;
 &lt;/copyright&gt;&#xD;
 --------------------------------------------------------------------------------------------------------------------</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EdotCover_002EIde_002ECore_002EFilterManagement_002EModel_002ESolutionFilterSettingsManagerMigrateSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>

--- a/src/Orc.Controls/Controls/Expander/Themes/Expander.generic.xaml
+++ b/src/Orc.Controls/Controls/Expander/Themes/Expander.generic.xaml
@@ -132,6 +132,7 @@
                                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                                 <ToggleButton x:Name="HeaderSite"
                                               Style="{StaticResource ExpanderHeaderToggleButtonStyle}"
+                                              BorderThickness="{TemplateBinding BorderThickness}"
                                               ContentTemplate="{TemplateBinding HeaderTemplate}" 
 								              ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" 
 								              Content="{TemplateBinding Header}" 

--- a/src/Orc.Controls/Controls/FontImage/FontImage.cs
+++ b/src/Orc.Controls/Controls/FontImage/FontImage.cs
@@ -1,11 +1,13 @@
 ﻿namespace Orc.Controls
 {
     using System;
+    using System.Drawing;
     using System.Windows;
     using System.Windows.Controls;
     using System.Windows.Media;
     using Catel.Logging;
     using Catel.Windows.Data;
+    using Image = System.Windows.Controls.Image;
 
     [TemplatePart(Name = "PART_Image", Type = typeof(Image))]
     public class FontImage : Control
@@ -29,9 +31,9 @@
 
         public static readonly DependencyProperty ItemNameProperty = DependencyProperty.Register(
             nameof(ItemName), typeof(string), typeof(FontImage), new PropertyMetadata(default(string),
-                (sender, args) => ((FontImage)sender).OnItemNameChanged(args)));
+                (sender, _) => ((FontImage)sender).OnItemNameChanged()));
 
-        private void OnItemNameChanged(DependencyPropertyChangedEventArgs args)
+        private void OnItemNameChanged()
         {
             Update();
         }
@@ -40,7 +42,7 @@
         #region Methods
         public override void OnApplyTemplate()
         {
-            _image = GetTemplateChild("PART_Image") as Image;
+            _image = GetTemplateChild("PART_Image") as Image; 
             if (_image is null)
             {
                 throw Log.ErrorAndCreateException<InvalidOperationException>("Can't find template part 'PART_Image'");
@@ -70,8 +72,14 @@
             {
                 return null;
             }
-            
+
             var fontName = fontFamily.ToString();
+            var isFontExist = IsFontInstalled(fontName);
+            if (!isFontExist)
+            {
+                return null;
+            }
+
             var registeredFont = Theming.FontImage.GetRegisteredFont(fontName);
             if (registeredFont is null)
             {
@@ -90,6 +98,12 @@
             {
                 return null;
             }
+        }
+
+        private static bool IsFontInstalled(string fontName)
+        {
+            using var testFont = new Font(fontName, 8);
+            return 0 == string.Compare(fontName, testFont.Name, StringComparison.InvariantCultureIgnoreCase);
         }
         #endregion
     }

--- a/src/Orc.Controls/Controls/FontImage/FontImage.cs
+++ b/src/Orc.Controls/Controls/FontImage/FontImage.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Drawing;
+    using System.Linq;
     using System.Windows;
     using System.Windows.Controls;
     using System.Windows.Media;
@@ -55,7 +56,7 @@
         }
 
         private void Update()
-        {
+        { 
             _image?.SetCurrentValue(Image.SourceProperty, GenerateImageSource());
         }
 
@@ -74,18 +75,18 @@
             }
 
             var fontName = fontFamily.ToString();
-            var isFontExist = IsFontInstalled(fontName);
-            if (!isFontExist)
-            {
-                return null;
-            }
-
             var registeredFont = Theming.FontImage.GetRegisteredFont(fontName);
+
             if (registeredFont is null)
             {
+                if (!IsFontInstalled(fontName))
+                {
+                    return null;
+                }
+
                 Theming.FontImage.RegisterFont(fontName, fontFamily);
             }
-
+            
             _fontImage.ItemName = itemName;
             _fontImage.FontFamily = fontName;
             _fontImage.Brush = Foreground;

--- a/src/Orc.Controls/Controls/FontImage/FontImage.cs
+++ b/src/Orc.Controls/Controls/FontImage/FontImage.cs
@@ -1,0 +1,96 @@
+﻿namespace Orc.Controls
+{
+    using System;
+    using System.Windows;
+    using System.Windows.Controls;
+    using System.Windows.Media;
+    using Catel.Logging;
+    using Catel.Windows.Data;
+
+    [TemplatePart(Name = "PART_Image", Type = typeof(Image))]
+    public class FontImage : Control
+    {
+        #region Constants
+        private static readonly ILog Log = LogManager.GetCurrentClassLogger();
+        #endregion
+
+        #region Fields
+        private Image _image;
+
+        private readonly Theming.FontImage _fontImage = new ();
+        #endregion
+
+        #region Dependency properties
+        public string ItemName
+        {
+            get { return (string)GetValue(ItemNameProperty); }
+            set { SetValue(ItemNameProperty, value); }
+        }
+
+        public static readonly DependencyProperty ItemNameProperty = DependencyProperty.Register(
+            nameof(ItemName), typeof(string), typeof(FontImage), new PropertyMetadata(default(string),
+                (sender, args) => ((FontImage)sender).OnItemNameChanged(args)));
+
+        private void OnItemNameChanged(DependencyPropertyChangedEventArgs args)
+        {
+            Update();
+        }
+        #endregion
+
+        #region Methods
+        public override void OnApplyTemplate()
+        {
+            _image = GetTemplateChild("PART_Image") as Image;
+            if (_image is null)
+            {
+                throw Log.ErrorAndCreateException<InvalidOperationException>("Can't find template part 'PART_Image'");
+            }
+            
+            Update();
+
+            this.SubscribeToDependencyProperty(nameof(FontFamily), (_, _) => Update());
+            this.SubscribeToDependencyProperty(nameof(Foreground), (_, _) => Update());
+        }
+
+        private void Update()
+        {
+            _image?.SetCurrentValue(Image.SourceProperty, GenerateImageSource());
+        }
+
+        private ImageSource GenerateImageSource()
+        {
+            var itemName = ItemName;
+            if (string.IsNullOrEmpty(itemName))
+            {
+                return null;
+            }
+
+            var fontFamily = FontFamily;
+            if (fontFamily is null)
+            {
+                return null;
+            }
+            
+            var fontName = fontFamily.ToString();
+            var registeredFont = Theming.FontImage.GetRegisteredFont(fontName);
+            if (registeredFont is null)
+            {
+                Theming.FontImage.RegisterFont(fontName, fontFamily);
+            }
+
+            _fontImage.ItemName = itemName;
+            _fontImage.FontFamily = fontName;
+            _fontImage.Brush = Foreground;
+
+            try
+            {
+                return _fontImage.GetImageSource();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+        #endregion
+    }
+}

--- a/src/Orc.Controls/Controls/FontImage/FontImage.cs
+++ b/src/Orc.Controls/Controls/FontImage/FontImage.cs
@@ -6,6 +6,7 @@
     using System.Windows;
     using System.Windows.Controls;
     using System.Windows.Media;
+    using Catel;
     using Catel.Logging;
     using Catel.Windows.Data;
     using Image = System.Windows.Controls.Image;
@@ -13,16 +14,12 @@
     [TemplatePart(Name = "PART_Image", Type = typeof(Image))]
     public class FontImage : Control
     {
-        #region Constants
         private static readonly ILog Log = LogManager.GetCurrentClassLogger();
-        #endregion
 
-        #region Fields
+        private readonly Theming.FontImage _fontImage = new();
+
         private Image _image;
-
-        private readonly Theming.FontImage _fontImage = new ();
-        #endregion
-
+        
         #region Dependency properties
         public string ItemName
         {
@@ -40,7 +37,6 @@
         }
         #endregion
 
-        #region Methods
         public override void OnApplyTemplate()
         {
             _image = GetTemplateChild("PART_Image") as Image; 
@@ -97,15 +93,21 @@
             }
             catch
             {
+                Log.Warning($"Can't get image source for Item = '{itemName}', Font='{fontName}'");
+
                 return null;
             }
         }
 
         private static bool IsFontInstalled(string fontName)
         {
+            if (string.IsNullOrWhiteSpace(fontName))
+            {
+                return false;
+            }
+
             using var testFont = new Font(fontName, 8);
-            return 0 == string.Compare(fontName, testFont.Name, StringComparison.InvariantCultureIgnoreCase);
+            return fontName.EqualsIgnoreCase(testFont.Name);
         }
-        #endregion
     }
 }

--- a/src/Orc.Controls/Controls/FontImage/Themes/FontImage.generic.xaml
+++ b/src/Orc.Controls/Controls/FontImage/Themes/FontImage.generic.xaml
@@ -8,6 +8,9 @@
 
     <Style x:Key="{x:Type controls:FontImage}" TargetType="{x:Type controls:FontImage}"
            BasedOn="{StaticResource Orc.Styles.Control}">
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="0"/>
+
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate>

--- a/src/Orc.Controls/Controls/FontImage/Themes/FontImage.generic.xaml
+++ b/src/Orc.Controls/Controls/FontImage/Themes/FontImage.generic.xaml
@@ -1,0 +1,25 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="clr-namespace:Orc.Controls">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="/Orc.Theming;component/themes/controls.implicit.wpf.control.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <Style x:Key="{x:Type controls:FontImage}" TargetType="{x:Type controls:FontImage}"
+           BasedOn="{StaticResource Orc.Styles.Control}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Border BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Background="{TemplateBinding Background}"
+                            Margin="{TemplateBinding Padding}">
+                        <Image x:Name="PART_Image"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/src/Orc.Controls/Helpers/DateTimeParser.cs
+++ b/src/Orc.Controls/Helpers/DateTimeParser.cs
@@ -1,11 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="DateTimeParser.cs" company="WildGums">
-//   Copyright (c) 2008 - 2018 WildGums. All rights reserved.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
-
-
-namespace Orc.Controls
+﻿namespace Orc.Controls
 {
     using System;
     using System.Linq;
@@ -14,11 +7,8 @@ namespace Orc.Controls
 
     public static class DateTimeParser
     {
-        #region Fields
         private static readonly ILog Log = LogManager.GetCurrentClassLogger();
-        #endregion
 
-        #region Methods
         public static DateTime Parse(string input, string format, bool isDateOnly = false)
         {
             return Parse(input, DateTimeFormatHelper.GetDateTimeFormatInfo(format, isDateOnly));
@@ -252,6 +242,5 @@ namespace Orc.Controls
 
             return null;
         }
-        #endregion
     }
 }

--- a/src/Orc.Controls/Orc.Controls.csproj
+++ b/src/Orc.Controls/Orc.Controls.csproj
@@ -50,6 +50,12 @@
     <PackageReference Update="NETStandard.Library" Version="2.0.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Page Update="Controls\FontImage\Themes\FontImage.generic.xaml">
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </Page>
+  </ItemGroup>
+
   <Import Project="$(MSBuildProjectDirectory)\..\Directory.Build.shared.explicit.props" Condition="Exists('$(MSBuildProjectDirectory)\..\Directory.Build.shared.explicit.props')" />
   <Import Project="$(MSBuildProjectDirectory)\..\Directory.Build.shared.mat.props" Condition="Exists('$(MSBuildProjectDirectory)\..\Directory.Build.shared.mat.props')" />
 </Project>

--- a/src/Orc.Controls/Orc.Controls.csproj
+++ b/src/Orc.Controls/Orc.Controls.csproj
@@ -50,12 +50,6 @@
     <PackageReference Update="NETStandard.Library" Version="2.0.3" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Page Update="Controls\FontImage\Themes\FontImage.generic.xaml">
-      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
-    </Page>
-  </ItemGroup>
-
   <Import Project="$(MSBuildProjectDirectory)\..\Directory.Build.shared.explicit.props" Condition="Exists('$(MSBuildProjectDirectory)\..\Directory.Build.shared.explicit.props')" />
   <Import Project="$(MSBuildProjectDirectory)\..\Directory.Build.shared.mat.props" Condition="Exists('$(MSBuildProjectDirectory)\..\Directory.Build.shared.mat.props')" />
 </Project>

--- a/src/Orc.Controls/Themes/Theming.defaultstyles.orccontrols.xaml
+++ b/src/Orc.Controls/Themes/Theming.defaultstyles.orccontrols.xaml
@@ -19,6 +19,7 @@
         <ResourceDictionary Source="/Orc.Controls;component/Controls/FilterBox/Themes/FilterBox.generic.xaml" />
         <ResourceDictionary Source="/Orc.Controls;component/Controls/FluidProgressBar/Themes/FluidProgressBar.generic.xaml" />
         <ResourceDictionary Source="/Orc.Controls;component/Controls/FluidProgressBar/Themes/FluidProgressBar.generic.xaml" />
+        <ResourceDictionary Source="/Orc.Controls;component/Controls/FontImage/Themes/FontImage.generic.xaml" />
         <ResourceDictionary Source="/Orc.Controls;component/Controls/SaveFilePicker/Themes/SaveFilePicker.generic.xaml" />
         <ResourceDictionary Source="/Orc.Controls;component/Controls/HeaderBar/Themes/HeaderBar.generic.xaml" />
         <ResourceDictionary Source="/Orc.Controls;component/Controls/LinkLabel/Themes/LinkLabel.generic.xaml" />


### PR DESCRIPTION
Control wrapper for FontImage Markup extension from Orc.Theming with ability to change Background/Foreground/ItemName/FontFamily through binding... sometimes it very useful just bind to text item, don't have to hide/show or change image source in standard Image control
example:
![image](https://user-images.githubusercontent.com/5163834/137774754-9898cbb0-255d-43ad-b8ba-e0844e5bbbf9.png)
usage:
![image](https://user-images.githubusercontent.com/5163834/137774849-ec38ab51-72ac-4bb5-ad5f-5805b37eeb3d.png)
