### PR TITLE
run dialogs in separate thread

### DIFF
--- a/src/Orc.Controls.Tests/PublicApiFacts.Orc_Controls_HasNoBreakingChanges_Async.verified.txt
+++ b/src/Orc.Controls.Tests/PublicApiFacts.Orc_Controls_HasNoBreakingChanges_Async.verified.txt
@@ -747,8 +747,9 @@ namespace Orc.Controls
         protected virtual void ApplyParameter(object? parameter) { }
         public override System.Threading.Tasks.Task CloseAsync() { }
         protected abstract T InitializeViewModel();
-        protected abstract void OnAccepted();
+        protected virtual void OnAccepted() { }
         protected override System.Threading.Tasks.Task OnOpenAsync(object? parameter = null) { }
+        protected virtual void OnRejected() { }
     }
     public class DirectoryPicker : Catel.Windows.Controls.UserControl, System.Windows.Markup.IComponentConnector
     {

--- a/src/Orc.Controls.Tests/Tools/DialogWindowHostedToolBaseTests.cs
+++ b/src/Orc.Controls.Tests/Tools/DialogWindowHostedToolBaseTests.cs
@@ -22,13 +22,9 @@ public class DialogWindowHostedToolBaseTests
         iuiVisualizerServiceMock.Setup(x => x.ShowContextAsync(It.IsAny<UIVisualizerContext>()))
             .Callback<UIVisualizerContext>(x =>
             {
-                //Run it in a thread of window
-                Task.Run(async () =>
-                {
-                    await Task.Delay(windowLifeTime);
+                Thread.Sleep(windowLifeTime);
 
-                    x.CompletedCallback?.Invoke(x, new UICompletedEventArgs(new UIVisualizerResult(true, x, null)));
-                });
+                x.CompletedCallback?.Invoke(x, new UICompletedEventArgs(new UIVisualizerResult(true, x, null)));
             });
         var iuiVisualizerServiceMockObject = iuiVisualizerServiceMock.Object;
 

--- a/src/Orc.Controls/Tools/DialogWindowHostedToolBase.cs
+++ b/src/Orc.Controls/Tools/DialogWindowHostedToolBase.cs
@@ -44,11 +44,11 @@ public abstract class DialogWindowHostedToolBase<T> : ControlToolBase
 
         if (IsModal)
         {
-            Task.Run(() => _uiVisualizerService.ShowDialogAsync(_windowViewModel, OnWindowCompleted));
+            Task.Run(async () => await _uiVisualizerService.ShowDialogAsync(_windowViewModel, OnWindowCompleted));
         }
         else
         {
-            Task.Run(() => _uiVisualizerService.ShowAsync(_windowViewModel, OnWindowCompleted));
+            Task.Run(async () => await _uiVisualizerService.ShowAsync(_windowViewModel, OnWindowCompleted));
         }
 
         return Task.CompletedTask;

--- a/src/Orc.Controls/Tools/DialogWindowHostedToolBase.cs
+++ b/src/Orc.Controls/Tools/DialogWindowHostedToolBase.cs
@@ -44,11 +44,11 @@ public abstract class DialogWindowHostedToolBase<T> : ControlToolBase
 
         if (IsModal)
         {
-            _uiVisualizerService.ShowDialogAsync(_windowViewModel, OnWindowCompleted);
+            Task.Run(() => _uiVisualizerService.ShowDialogAsync(_windowViewModel, OnWindowCompleted));
         }
         else
         {
-            _uiVisualizerService.ShowAsync(_windowViewModel, OnWindowCompleted);
+            Task.Run(() => _uiVisualizerService.ShowAsync(_windowViewModel, OnWindowCompleted));
         }
 
         return Task.CompletedTask;
@@ -62,9 +62,22 @@ public abstract class DialogWindowHostedToolBase<T> : ControlToolBase
         {
             OnAccepted();
         }
+        else
+        {
+            OnRejected();
+        }
     }
 
-    protected abstract void OnAccepted();
+    protected virtual void OnRejected()
+    {
+        
+    }
+
+    protected virtual void OnAccepted()
+    {
+
+    }
+
     protected abstract T InitializeViewModel();
 
     protected virtual void ApplyParameter(object? parameter)

--- a/src/Orc.Controls/Tools/FindReplace/FindReplaceTool.cs
+++ b/src/Orc.Controls/Tools/FindReplace/FindReplaceTool.cs
@@ -3,7 +3,6 @@
 using System;
 using Catel.IoC;
 using Catel.Logging;
-using Catel.MVVM;
 using Catel.Services;
 using Services;
 using ViewModels;


### PR DESCRIPTION
Run dialogs in separate thread.
Test: After_Closing_Tool_Dialog_Tool_Must_Be_Closed_But_Not_Before_Async (was fixed)
