### PR TITLE
Hotfix/5.0.4

### DIFF
--- a/src/Orc.Controls/Tools/Management/ControlToolManager.cs
+++ b/src/Orc.Controls/Tools/Management/ControlToolManager.cs
@@ -197,7 +197,7 @@ public class ControlToolManager : IControlToolManager
             catch (Exception e)
             {
                 //Vladimir:Don't crash if something went wrong while saving tool settings into file
-                Log.Error(e);
+                Log.Debug(e);
             }
         }
     }


### PR DESCRIPTION
do not log error when control settings can't be found