### PR TITLE
do not show log error in customers app if it's impossible to find set…

### DIFF
--- a/src/Orc.Controls/Tools/Management/ControlToolManager.cs
+++ b/src/Orc.Controls/Tools/Management/ControlToolManager.cs
@@ -167,7 +167,7 @@ public class ControlToolManager : IControlToolManager
             catch (Exception e)
             {
                 //Vladimir:Don't crash if something went wrong while loading file
-                Log.Error(e);
+                Log.Debug(e);
             }
         }
     }


### PR DESCRIPTION
do not Log.Error on control tool settings load/save 