### PR TITLE
Fix control adapter initialization

### DIFF
--- a/src/Orc.Controls.Settings/Behaviors/ControlSettingsBehavior.cs
+++ b/src/Orc.Controls.Settings/Behaviors/ControlSettingsBehavior.cs
@@ -79,7 +79,7 @@ public partial class ControlSettingsBehavior<TControl, TSettings> : BehaviorBase
         get => (ISettingsStorage<TSettings>?)GetValue(SettingsStorageProperty);
         set => SetValue(SettingsStorageProperty, value);
     }
-    public IControlSettingsAdapter<TControl, TSettings> ControlSettingsAdapter { get; }
+
     public IControlSettingsAdapter<TControl, TSettings>? ControlAdapter
     {
         get => (IControlSettingsAdapter<TControl, TSettings>?)GetValue(ControlAdapterProperty);
@@ -107,7 +107,8 @@ public partial class ControlSettingsBehavior<TControl, TSettings> : BehaviorBase
         _settingsKeyInteractionHub = settingsKeyInteractionHub;
 
         SettingsStorage = settingsStorage;
-        ControlSettingsAdapter = controlSettingsAdapter;
+
+        SetCurrentValue(ControlAdapterProperty, controlSettingsAdapter);
     }
 
     protected override void OnAssociatedObjectLoaded()

--- a/src/Orc.Controls.Tests/PublicApiFacts.Orc_Controls_Settings_HasNoBreakingChanges_Async.verified.txt
+++ b/src/Orc.Controls.Tests/PublicApiFacts.Orc_Controls_Settings_HasNoBreakingChanges_Async.verified.txt
@@ -65,7 +65,6 @@ namespace Orc.Controls.Settings
         public ControlSettingsBehavior(Orc.Controls.Settings.ISettingsKeyManager settingsKeyManager, Orc.Controls.Settings.ISettingsStateStorage settingsStateStorage, Orc.Controls.Settings.ISettingsKeyInteractionHub settingsKeyInteractionHub, Orc.Controls.Settings.ISettingsStorage<TSettings> settingsStorage, Orc.Controls.Settings.IControlSettingsAdapter<TControl, TSettings> controlSettingsAdapter) { }
         public System.Windows.FrameworkElement? Control { get; }
         public Orc.Controls.Settings.IControlSettingsAdapter<TControl, TSettings>? ControlAdapter { get; set; }
-        public Orc.Controls.Settings.IControlSettingsAdapter<TControl, TSettings> ControlSettingsAdapter { get; }
         public bool EnableSynchronization { get; set; }
         public Orc.Controls.Settings.InitialKeySettings InitialKeySettings { get; set; }
         public bool IsAutosave { get; set; }


### PR DESCRIPTION
Remove redundant auto-property and consistently initialize the ControlAdapter via its dependency property.

### Description of Change ###

<!-- Describe your changes here -->

### Issues Resolved ### 

<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###

<!-- List all API changes here (or just put None) -->
 
None

### Behavioral Changes ###

<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###

<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] I have included examples or tests
- [ ] I have updated the change log or created a GitHub ticket with the change
- [ ] I am listed in the CONTRIBUTORS file (if it exists)
- [ ] Changes adhere to coding standard
- [ ] I checked the licenses of Third Party software and discussed new dependencies with at least 1 other team member